### PR TITLE
fix: increase function timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
           event_trigger_resource: projects/${{ secrets.PROJECT_ID }}/topics/monday-morning-topic
           deploy_timeout: 600
           memory_mb: 512
+          timeout: 240
           env_vars: STORAGE_BUCKET=${{secrets.STORAGE_BUCKET}}
           secret_volumes: |
             /secrets/app/secrets.json=${{secrets.PROJECT_ID}}/app_secrets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,7 @@ jobs:
           event_trigger_resource: projects/${{ secrets.PROJECT_ID }}/topics/monday-morning-topic
           deploy_timeout: 600
           memory_mb: 512
+          timeout: 240
           env_vars: STORAGE_BUCKET=${{secrets.STORAGE_BUCKET}}
           secret_volumes: |
             /secrets/app/secrets.json=${{secrets.PROJECT_ID}}/app_secrets


### PR DESCRIPTION
The function currently times out at 60 seconds, which is right on the border of the function's runtime (depending on latency to SFTP/AGOL). Increasing to 4 minutes to give plenty of headroom.